### PR TITLE
include <compare> for std::*meow*_ordering

### DIFF
--- a/life_string_view.h
+++ b/life_string_view.h
@@ -4,6 +4,10 @@
 #include <memory>
 #include <utility>
 
+#if __cplusplus >= 202002L
+#include <compare>
+#endif
+
 namespace life {
 
 class life_string_view {


### PR DESCRIPTION
> The three comparison category types are **not predefined**; if a standard library declaration of such a class type does not precede a use of that type — **even an implicit use in which the type is not named in a defaulted three-way comparison or use of the built-in operator** — the program is ill-formed.

cf. https://eel.is/c++draft/expr.spaceship#8