### PR TITLE
Fix compare support for old C++

### DIFF
--- a/life_string_view.h
+++ b/life_string_view.h
@@ -251,11 +251,17 @@ public:
         return a.data_ == b;
     }
 #if __cplusplus < 202002L
+    friend bool operator==(const char* a, life_string_view b) noexcept {
+        return a == b.data_;
+    }
     friend bool operator!=(life_string_view a, life_string_view b) noexcept {
         return a.data_ != b.data_;
     }
     friend bool operator!=(life_string_view a, const char* b) noexcept {
         return a.data_ != b;
+    }
+    friend bool operator!=(const char* a, life_string_view b) noexcept {
+        return a != b.data_;
     }
 #endif
 

--- a/life_string_view.h
+++ b/life_string_view.h
@@ -269,18 +269,45 @@ public:
     friend auto operator<=>(life_string_view a, life_string_view b) noexcept {
         return a.data_ <=> b.data_;
     }
+    friend auto operator<=>(const life_string_view& a, const char* b) noexcept {
+        return a.data_ <=> b;
+    }
 #else
     friend bool operator<(life_string_view a, life_string_view b) noexcept {
         return a.data_ < b.data_;
     }
+    friend bool operator<(const life_string_view& a, const char* b) noexcept {
+        return a.data_ < b;
+    }
+    friend bool operator<(const char* a, const life_string_view& b) noexcept {
+        return a < b.data_;
+    }
     friend bool operator<=(life_string_view a, life_string_view b) noexcept {
         return a.data_ <= b.data_;
+    }
+    friend bool operator<=(const life_string_view& a, const char* b) noexcept {
+        return a.data_ <= b;
+    }
+    friend bool operator<=(const char* a, const life_string_view& b) noexcept {
+        return a <= b.data_;
     }
     friend bool operator>(life_string_view a, life_string_view b) noexcept {
         return a.data_ > b.data_;
     }
+    friend bool operator>(const life_string_view& a, const char* b) noexcept {
+        return a.data_ > b;
+    }
+    friend bool operator>(const char* a, const life_string_view& b) noexcept {
+        return a > b.data_;
+    }
     friend bool operator>=(life_string_view a, life_string_view b) noexcept {
         return a.data_ >= b.data_;
+    }
+    friend bool operator>=(const life_string_view& a, const char* b) noexcept {
+        return a.data_ >= b;
+    }
+    friend bool operator>=(const char* a, const life_string_view& b) noexcept {
+        return a >= b.data_;
     }
 #endif
 


### PR DESCRIPTION
- C++17以前だと異なる型同士の比較演算は左右それぞれ定義が必要なので追加
- `operator<` とかで文字列リテラルとそのまま比較できなかったので対応
    - ところで本質的には `life_string_view` が `const char*` から直接(暗黙に)構築できないことに起因する問題だと思っていて，こっち側で解決するべきなのかはうーんという感じ(ところでこれはライブラリ本体のdesign decisionだと思っていて，私の一存で決める話でもないので一旦この対応で…)